### PR TITLE
convert sync'ed time to epoch ros time, and compress console output

### DIFF
--- a/src/SickSafetyscannersRos.cpp
+++ b/src/SickSafetyscannersRos.cpp
@@ -382,7 +382,12 @@ SickSafetyscannersRos::createLaserScanMessage(const sick::datastructure::Data& d
 {
   sensor_msgs::LaserScan scan;
   scan.header.frame_id = m_frame_id;
-  scan.header.stamp    = ros::Time::now();
+
+  std::shared_ptr<sick::datastructure::DataHeader> data_header = data.getDataHeaderPtr();
+  double data_ts = (data_header->getTimestampDate() /*days since 01/01/1972*/ + 730u /*epoch time starts at 01/01/1970*/) * 86400. +
+                   data_header->getTimestampTime() /*milli-seconds since midnight*/ * 1e-3;
+  scan.header.stamp = ros::Time(data_ts);
+
   // Add time offset (to account for network latency etc.)
   scan.header.stamp += ros::Duration().fromSec(m_time_offset);
   // TODO check why returned number of beams is misaligned to size of vector


### PR DESCRIPTION
```
hardware_1      | [/front_laser/front_laser] [1624487988.688644774]: ros time: sec 1624487988 nsec 688624258
hardware_1      | [/front_laser/front_laser] [1624487988.688684234]: header date: 18071
hardware_1      | [/front_laser/front_laser] [1624487988.688705893]: header time: 81588594
hardware_1      | [/front_laser/front_laser] [1624487988.688724780]: converted sec 1624487988 nsec 594000101
hardware_1      | [/forward_camera/driver] [1624487988.743735578]: Beginning capture from 1 cameras
hardware_1      | [/back_left_laser/back_left_laser] [1624487989.331378918]: ros time: sec 1624487989 nsec 331356240
hardware_1      | [/back_left_laser/back_left_laser] [1624487989.331415935]: header date: 18071
hardware_1      | [/back_left_laser/back_left_laser] [1624487989.331434300]: header time: 81589237
hardware_1      | [/back_left_laser/back_left_laser] [1624487989.331452143]: converted sec 1624487989 nsec 236999989
hardware_1      | [/back_right_laser/back_right_laser] [1624487989.941026482]: ros time: sec 1624487989 nsec 941005734
hardware_1      | [/back_right_laser/back_right_laser] [1624487989.941061026]: header date: 18071
hardware_1      | [/back_right_laser/back_right_laser] [1624487989.941077075]: header time: 81589847
hardware_1      | [/back_right_laser/back_right_laser] [1624487989.941091925]: converted sec 1624487989 nsec 846999884
bag_uploader_1  | An exception occurred in the bag_uploader main loop: [Errno -3] Temporary failure in name resolution
hardware_1      | [/front_laser/front_laser] [1624487990.693248284]: ros time: sec 1624487990 nsec 693227801
hardware_1      | [/front_laser/front_laser] [1624487990.693279599]: header date: 18071
hardware_1      | [/front_laser/front_laser] [1624487990.693293275]: header time: 81590604
hardware_1      | [/front_laser/front_laser] [1624487990.693313232]: converted sec 1624487990 nsec 604000092
hardware_1      | [/back_left_laser/back_left_laser] [1624487991.340921700]: ros time: sec 1624487991 nsec 340899431
hardware_1      | [/back_left_laser/back_left_laser] [1624487991.340953025]: header date: 18071
hardware_1      | [/back_left_laser/back_left_laser] [1624487991.340989270]: header time: 81591248
hardware_1      | [/back_left_laser/back_left_laser] [1624487991.341014147]: converted sec 1624487991 nsec 247999907
hardware_1      | [/back_right_laser/back_right_laser] [1624487991.950920025]: ros time: sec 1624487991 nsec 950899532
hardware_1      | [/back_right_laser/back_right_laser] [1624487991.950953824]: header date: 18071
hardware_1      | [/back_right_laser/back_right_laser] [1624487991.950970076]: header time: 81591853
hardware_1      | [/back_right_laser/back_right_laser] [1624487991.950987457]: converted sec 1624487991 nsec 852999926
hardware_1      | [/front_laser/front_laser] [1624487992.702943721]: ros time: sec 1624487992 nsec 702921869
hardware_1      | [/front_laser/front_laser] [1624487992.703041763]: header date: 18071
hardware_1      | [/front_laser/front_laser] [1624487992.703061674]: header time: 81592612
hardware_1      | [/front_laser/front_laser] [1624487992.703077449]: converted sec 1624487992 nsec 611999989
hardware_1      | [/back_left_laser/back_left_laser] [1624487993.350599424]: ros time: sec 1624487993 nsec 350574562
hardware_1      | [/back_left_laser/back_left_laser] [1624487993.350634140]: header date: 18071
hardware_1      | [/back_left_laser/back_left_laser] [1624487993.350652047]: header time: 81593257
hardware_1      | [/back_left_laser/back_left_laser] [1624487993.350670086]: converted sec 1624487993 nsec 256999969
